### PR TITLE
Add HTTP context forwarding for rpc-endpoint integration

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -755,21 +755,12 @@ func (b *Backend) doForward(ctx context.Context, rpcReqs []*RPCReq, isBatch bool
 		return nil, wrapErr(err, "error creating backend request")
 	}
 
+	// Forward all collected headers (includes URL-derived and request headers)
 	headersToForward := GetHeadersToForward(ctx)
-	if len(headersToForward) != 0 {
-		for k, v := range headersToForward {
-			for _, value := range v {
-				httpReq.Header.Add(k, value)
-			}
+	for k, v := range headersToForward {
+		for _, value := range v {
+			httpReq.Header.Add(k, value)
 		}
-	}
-
-	// Forward original URL context as headers for all methods
-	if path, ok := ctx.Value(ContextKeyPath).(string); ok && path != "" && path != "/" {
-		httpReq.Header.Set("X-Original-Path", path)
-	}
-	if rawQuery, ok := ctx.Value(ContextKeyRawQuery).(string); ok && rawQuery != "" {
-		httpReq.Header.Set("X-Original-Query", rawQuery)
 	}
 
 	if b.authPassword != "" {


### PR DESCRIPTION
## Summary
Enables proxyd to forward HTTP context (path, query parameters, headers) to backend services, specifically supporting the new unified ingress architecture where rpc-endpoint handles special processing.

## Part of Unified Ingress Architecture
- **Goal**: Single proxyd ingress for all traffic (users, wallets, searchers)  
- **Current**: RPC endpoint serves as ingress → handles special methods → routes rest to egress
- **New**: Proxyd ingress → routes special methods to rpc-endpoint OR standard methods direct to upstream
- **Companion PR**: flashbots/devops (Sepolia configuration coming)

## Technical Changes
- HTTP context forwarding capability for backend routing
- Enables rpc-endpoint to receive full request context (path, query params, headers) for special method processing

**Status**: Draft - Part of larger architectural change

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>